### PR TITLE
Add IndoML 2025 news, TALLIP publication entry, and Semantic Scholar citation counts

### DIFF
--- a/_includes/widgets/publication_item.html
+++ b/_includes/widgets/publication_item.html
@@ -22,7 +22,15 @@
                 <a target="_blank" href="{{ link[1] }}">[{{ link[0] }}]</a>
                 {% endif %}
                 {% endfor %}
+                {% if item.semantic_scholar_id %}
+                <a target="_blank" rel="noopener" href="https://www.semanticscholar.org/paper/CorpusID:{{ item.semantic_scholar_id }}">[Semantic Scholar]</a>
+                {% endif %}
             </p>
+            {% if item.semantic_scholar_id %}
+            <p class="mt-0 mb-0 small text-muted">
+                Citations: <span class="citation-count" data-semantic-scholar-id="{{ item.semantic_scholar_id }}">--</span>
+            </p>
+            {% endif %}
 
         </div>
     </div>
@@ -46,7 +54,15 @@
                     <a target="_blank" href="{{ link[1] }}">[{{ link[0] }}]</a>
                     {% endif %}
                     {% endfor %}
+                    {% if item.semantic_scholar_id %}
+                    <a target="_blank" rel="noopener" href="https://www.semanticscholar.org/paper/CorpusID:{{ item.semantic_scholar_id }}">[Semantic Scholar]</a>
+                    {% endif %}
                 </p>
+                {% if item.semantic_scholar_id %}
+                <p class="mt-0 mb-0 small text-muted">
+                    Citations: <span class="citation-count" data-semantic-scholar-id="{{ item.semantic_scholar_id }}">--</span>
+                </p>
+                {% endif %}
             </div>
         </div>
     </div>

--- a/_publications/2025/2025-contextual-post-ocr-correction.md
+++ b/_publications/2025/2025-contextual-post-ocr-correction.md
@@ -1,0 +1,10 @@
+---
+title:          "A Framework and Dataset for Contextual Post-OCR Correction"
+date:           2025-09-01 00:01:00 +0530
+pub_pre:        "Accepted in "
+pub:            "ACM Transactions on Asian and Low-Resource Language Information Processing (TALLIP)"
+abstract: >-
+  This paper presents a framework and dataset for contextual post-OCR correction to improve text quality in low-resource and noisy OCR settings.
+authors:
+  - <strong>A Bhandari</strong>
+---

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -38,4 +38,36 @@ $(function () {
     $(".lazy").on("load", function () {
         $grid.masonry('layout');
     });
+
+    const citationNodes = document.querySelectorAll('[data-semantic-scholar-id]');
+    if (citationNodes.length) {
+        const ids = Array.from(new Set(Array.from(citationNodes).map((node) => node.dataset.semanticScholarId)));
+        const updateNodes = (id, value) => {
+            citationNodes.forEach((node) => {
+                if (node.dataset.semanticScholarId === id) {
+                    node.textContent = value;
+                }
+            });
+        };
+
+        ids.forEach((id) => {
+            fetch(`https://api.semanticscholar.org/paper/CorpusID:${id}?fields=citationCount`)
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error(`Semantic Scholar request failed: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then((data) => {
+                    if (typeof data.citationCount === 'number') {
+                        updateNodes(id, data.citationCount.toString());
+                    } else {
+                        updateNodes(id, 'N/A');
+                    }
+                })
+                .catch(() => {
+                    updateNodes(id, 'N/A');
+                });
+        });
+    }
 })

--- a/news/2025-01-20-indoml-2025-travel-grant.md
+++ b/news/2025-01-20-indoml-2025-travel-grant.md
@@ -1,0 +1,5 @@
+---
+title: "Received IndoML 2025 Travel Grant"
+date: 2025-01-20 00:00:00 +0530
+---
+Received a travel grant for IndoML 2025.

--- a/news/2025-01-27-indoml-2025-attendance.md
+++ b/news/2025-01-27-indoml-2025-attendance.md
@@ -1,0 +1,5 @@
+---
+title: "Attended IndoML 2025"
+date: 2025-01-27 00:00:00 +0530
+---
+Attended IndoML 2025 and participated in the conference activities.


### PR DESCRIPTION
### Motivation
- Record IndoML 2025 updates (travel grant and attendance) in the site's news feed.
- Add the accepted publication entry for "A Framework and Dataset for Contextual Post-OCR Correction" with the full journal name (ACM Transactions on Asian and Low-Resource Language Information Processing (TALLIP)).
- Make per-publication Semantic Scholar IDs usable by showing a link and live citation counts on publication cards.

### Description
- Added two news items: `news/2025-01-20-indoml-2025-travel-grant.md` and `news/2025-01-27-indoml-2025-attendance.md` with appropriate dates and short content. 
- Added publication entry `_publications/2025/2025-contextual-post-ocr-correction.md` with `pub_pre` and `pub` set to the full TALLIP journal name. 
- Updated `_includes/widgets/publication_item.html` to render a `[Semantic Scholar]` link when `semantic_scholar_id` is present and to include a `span` placeholder showing citation counts (`data-semantic-scholar-id`).
- Added client-side code in `assets/js/common.js` to fetch `citationCount` from the Semantic Scholar API (`https://api.semanticscholar.org/paper/CorpusID:<id>?fields=citationCount`) and populate all matching citation placeholders; errors result in `N/A`.

### Testing
- Launched a local static server with `python -m http.server 8000` and it started successfully. 
- Ran a Playwright script to load `http://127.0.0.1:8000/publications.html` and capture a screenshot, which completed and produced the artifact `artifacts/publications-citations.png` (succeeded).
- Attempted direct `curl` requests to external sites during testing which returned `HTTP 403` due to network/proxy restrictions, indicating that live Semantic Scholar API calls may be blocked in the test environment (failed for external requests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968737f6808832fbfa262508afed485)