### PR TITLE
Revert repository to commit 8fe1237 — restore publications and remove citation integration

### DIFF
--- a/_includes/widgets/publication_item.html
+++ b/_includes/widgets/publication_item.html
@@ -22,12 +22,7 @@
                 <a target="_blank" href="{{ link[1] }}">[{{ link[0] }}]</a>
                 {% endif %}
                 {% endfor %}
-                {% if item.semantic_scholar_id %}
-                <a target="_blank" rel="noopener" href="https://www.semanticscholar.org/paper/CorpusID:{{ item.semantic_scholar_id }}">[Semantic Scholar]</a>
-                <span>[Citations: <span class="citation-count" data-semantic-scholar-id="{{ item.semantic_scholar_id }}">--</span>]</span>
-                {% endif %}
             </p>
-            {% endif %}
 
         </div>
     </div>
@@ -51,16 +46,7 @@
                     <a target="_blank" href="{{ link[1] }}">[{{ link[0] }}]</a>
                     {% endif %}
                     {% endfor %}
-                    {% if item.semantic_scholar_id %}
-                    <a target="_blank" rel="noopener" href="https://www.semanticscholar.org/paper/CorpusID:{{ item.semantic_scholar_id }}">[Semantic Scholar]</a>
-                    <span>[Citations: <span class="citation-count" data-semantic-scholar-id="{{ item.semantic_scholar_id }}">--</span>]</span>
-                    {% endif %}
                 </p>
-                {% if item.semantic_scholar_id %}
-                <p class="mt-0 mb-0 small text-muted">
-                    Citations: <span class="citation-count" data-semantic-scholar-id="{{ item.semantic_scholar_id }}">--</span>
-                </p>
-                {% endif %}
             </div>
         </div>
     </div>

--- a/_publications/2025/2025-mind-the-language-gap.md
+++ b/_publications/2025/2025-mind-the-language-gap.md
@@ -1,18 +1,18 @@
 ---
-title:          "Mind the (Language) Gap: Towards Probing Numerical and Cross-Lingual Limits of LVLMs"
-date:           2025-08-24 00:01:00 +0530
-selected:       true
-pub:            "Proceedings of the 5th Workshop on Multilingual Representation Learning (MRL 2025)"
-semantic_scholar_id: 280711862
-abstract: >-
-  This paper introduces MMCRICBENCH-3K, a benchmark for Visual Question Answering on cricket scorecards designed to evaluate large vision-language models on complex numerical and cross-lingual reasoning over semi-structured tabular images. Empirical results show that state-of-the-art models struggle with structure-aware numerical reasoning and cross-lingual generalization.
-cover:          /assets/images/covers/MMCricbench.png
-authors:
-  - S Gautam
-  - AS Penamakuri
-  - <strong>A Bhandari</strong>
-  - G Harit
-links:
-  Paper: https://aclanthology.org/2025.mrl-main.38.pdf
-  Dataset: https://huggingface.co/datasets/DIALab/MMCricBench
+    title:          "Mind the (Language) Gap: Towards Probing Numerical and Cross-Lingual Limits of LVLMs"
+    date:           2025-08-24 00:01:00 +0530
+    selected:       true
+    pub:            "Proceedings of the 5th Workshop on Multilingual Representation Learning (MRL 2025)"
+
+    abstract: >-
+      This paper introduces MMCRICBENCH-3K, a benchmark for Visual Question Answering on cricket scorecards designed to evaluate large vision-language models on complex numerical and cross-lingual reasoning over semi-structured tabular images. Empirical results show that state-of-the-art models struggle with structure-aware numerical reasoning and cross-lingual generalization.
+    cover:          /assets/images/covers/MMCricbench.png
+    authors:
+      - S Gautam
+      - AS Penamakuri
+      - <strong>A Bhandari</strong>
+      - G Harit
+    links:
+      Paper: https://aclanthology.org/2025.mrl-main.38.pdf
+      Dataset: https://huggingface.co/datasets/DIALab/MMCricBench
 ---

--- a/_publications/2025/2025-tabcomp-dataset.md
+++ b/_publications/2025/2025-tabcomp-dataset.md
@@ -3,8 +3,8 @@ title:          "TabComp: A Dataset for Visual Table Reading Comprehension"
 date:           2025-01-01 00:01:00 +0530
 selected:       true
 pub:            "Findings of the Association for Computational Linguistics: NAACL 2025"
-semantic_scholar_id: 278664723
-abstract: >- 
+
+abstract: >-
   This paper introduces TabComp, a dataset for visual table reading comprehension. The dataset is designed to advance research in understanding and extracting information from tables in documents.
 cover:          /assets/images/covers/Tabcomp.png
 authors:

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -38,36 +38,4 @@ $(function () {
     $(".lazy").on("load", function () {
         $grid.masonry('layout');
     });
-
-    const citationNodes = document.querySelectorAll('[data-semantic-scholar-id]');
-    if (citationNodes.length) {
-        const ids = Array.from(new Set(Array.from(citationNodes).map((node) => node.dataset.semanticScholarId)));
-        const updateNodes = (id, value) => {
-            citationNodes.forEach((node) => {
-                if (node.dataset.semanticScholarId === id) {
-                    node.textContent = value;
-                }
-            });
-        };
-
-        ids.forEach((id) => {
-            fetch(`https://api.semanticscholar.org/paper/CorpusID:${id}?fields=citationCount`)
-                .then((response) => {
-                    if (!response.ok) {
-                        throw new Error(`Semantic Scholar request failed: ${response.status}`);
-                    }
-                    return response.json();
-                })
-                .then((data) => {
-                    if (typeof data.citationCount === 'number') {
-                        updateNodes(id, data.citationCount.toString());
-                    } else {
-                        updateNodes(id, 'N/A');
-                    }
-                })
-                .catch(() => {
-                    updateNodes(id, 'N/A');
-                });
-        });
-    }
 })


### PR DESCRIPTION
### Motivation
- Restore the repository state to commit `8fe1237...` to bring back the previous publication listing markup and publication metadata. 
- Remove the Semantic Scholar citation integration that was added later to avoid displaying broken or unnecessary citation counts. 
- Ensure the site files match the earlier committed content for consistency with the published site.

### Description
- Reverted the publication item template in `_includes/widgets/publication_item.html` to the earlier markup and removed the inline Semantic Scholar link and citation elements. 
- Restored publication metadata files ` _publications/2025/2025-mind-the-language-gap.md` and `_publications/2025/2025-tabcomp-dataset.md` to their prior content and formatting, removing the `semantic_scholar_id` entries where present. 
- Removed the Semantic Scholar citation fetching logic from `assets/js/common.js` so the frontend no longer attempts to fetch citation counts. 
- Committed these changes to the working branch as a revert to match the specified commit state.

### Testing
- Attempted to build the site with `bundle exec jekyll build`, which failed due to missing gem executables (`bundler: command not found: jekyll`), so a full Jekyll build could not be validated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69688e63e7e8832f8c3d78f10c4d25c5)